### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 *What This Script Does*
 
 - Command pulls the most current copy of the compile script executes it 
-- Updates the componants as needed  
+- Updates the components as needed  
 - Pulls the newest HighFidelity code and compiles it 
 - Creates a user named `hifi` to run HighFidelity DS/AC under (for security reasons)
 - Writes to the `/etc/profile.d/coal.sh` file the aliases for these local commands 


### PR DESCRIPTION
@nbq, I've corrected a typographical error in the documentation of the [hifi-compile-scripts](https://github.com/nbq/hifi-compile-scripts) project. Specifically, I've changed componant to component. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
